### PR TITLE
Toggle autounlock command without arguments

### DIFF
--- a/src/org/starloco/locos/command/CommandPlayer.java
+++ b/src/org/starloco/locos/command/CommandPlayer.java
@@ -551,19 +551,11 @@ public class CommandPlayer {
     }
 
     private static boolean commandAutoUnlock(Player player, String msg) {
-        String[] parts = msg.split(" ");
-        if (parts.length < 2) {
-            player.sendMessage("Usage: .autounlock on/off");
-            return true;
-        }
-        if (parts[1].equalsIgnoreCase("on")) {
-            player.setAutoUnlock(true);
+        player.setAutoUnlock(!player.isAutoUnlock());
+        if (player.isAutoUnlock()) {
             player.sendMessage("Auto unlock enabled");
-        } else if (parts[1].equalsIgnoreCase("off")) {
-            player.setAutoUnlock(false);
-            player.sendMessage("Auto unlock disabled");
         } else {
-            player.sendMessage("Usage: .autounlock on/off");
+            player.sendMessage("Auto unlock disabled");
         }
         return true;
     }


### PR DESCRIPTION
## Summary
- Simplify `.autounlock` player command to toggle automatically between enabled and disabled states.
- Remove obsolete on/off argument handling.

## Testing
- `gradle test`


------
https://chatgpt.com/codex/tasks/task_e_68c7e13aac108329bcf5261259dff830