### PR TITLE
Fix job XP multiplier for script-driven gains

### DIFF
--- a/src/org/starloco/locos/script/proxy/SPlayer.java
+++ b/src/org/starloco/locos/script/proxy/SPlayer.java
@@ -18,6 +18,7 @@ import org.starloco.locos.game.world.World;
 import org.starloco.locos.job.Job;
 import org.starloco.locos.job.JobStat;
 import org.starloco.locos.kernel.Constant;
+import org.starloco.locos.kernel.Config;
 import org.starloco.locos.object.GameObject;
 import org.starloco.locos.object.ObjectTemplate;
 import org.starloco.locos.quest.QuestProgress;
@@ -602,7 +603,8 @@ public class SPlayer extends DefaultUserdata<Player> {
 
         JobStat js = p.getMetierByID(jobID);
         if(js == null) return false;
-        js.addXp(p, xpDelta);
+        long xpGain = (long) xpDelta * Config.rateJob;
+        js.addXp(p, xpGain);
 
         SocketManager.GAME_SEND_JX_PACKET(p, Collections.singletonList(js));
         return true;


### PR DESCRIPTION
## Summary
- ensure the scripting helper applies the configured job XP rate multiplier when granting XP
- import the game configuration so the multiplier is available in the script proxy

## Testing
- gradle test

------
https://chatgpt.com/codex/tasks/task_e_68c8f38825e88329892693d3abbd36a7