### PR TITLE
Adjust gather respawn timers to official ranges

### DIFF
--- a/scripts/data/skills/job_alchemist.lua
+++ b/scripts/data/skills/job_alchemist.lua
@@ -3,13 +3,13 @@ local toolIDs = {1473}
 
 --FIXME timing / Reward
 local gatherSkills = {
-    {id=68,  obj=Objects.Flax,            minLvl=0,   itemID=421,  xp=10, respawn={6000, 10000} },
-    {id=69,  obj=Objects.Hemp,            minLvl=10,  itemID=428,  xp=15, respawn={6000, 10000} },
-    {id=71,  obj=Objects.FiveLeafClover,  minLvl=20,  itemID=395,  xp=20, respawn={6000, 10000} },
-    {id=72,  obj=Objects.WildMint,        minLvl=30,  itemID=380,  xp=25, respawn={6000, 10000} },
-    {id=73,  obj=Objects.FreyesqueOrchid, minLvl=40,  itemID=593,  xp=30, respawn={6000, 10000} },
-    {id=74,  obj=Objects.Edelweiss,       minLvl=50,  itemID=594,  xp=35, respawn={6000, 10000} },
-    {id=160, obj=Objects.Pandkin,         minLvl=50,  itemID=7059, xp=35, respawn={6000, 10000} },
+    {id=68,  obj=Objects.Flax,            minLvl=0,   itemID=421,  xp=10, respawn={300000, 420000} },
+    {id=69,  obj=Objects.Hemp,            minLvl=10,  itemID=428,  xp=15, respawn={840000, 1200000} },
+    {id=71,  obj=Objects.FiveLeafClover,  minLvl=20,  itemID=395,  xp=20, respawn={660000, 960000} },
+    {id=72,  obj=Objects.WildMint,        minLvl=30,  itemID=380,  xp=25, respawn={720000, 1080000} },
+    {id=73,  obj=Objects.FreyesqueOrchid, minLvl=40,  itemID=593,  xp=30, respawn={900000, 1200000} },
+    {id=74,  obj=Objects.Edelweiss,       minLvl=50,  itemID=594,  xp=35, respawn={900000, 1200000} },
+    {id=160, obj=Objects.Pandkin,         minLvl=50,  itemID=7059, xp=35, respawn={780000, 1140000} },
 }
 
 registerGatherJobSkills(jobID, {toolIDs=toolIDs}, gatherSkills)

--- a/scripts/data/skills/job_farmer.lua
+++ b/scripts/data/skills/job_farmer.lua
@@ -5,15 +5,15 @@ local toolType = 22
 --FIXME timing / Reward
 --FIXME Reward special cereals sometimes
 local gatherSkills = {
-    {id=45,  obj=Objects.Wheat,  minLvl=0,   itemID=289,  xp=10, respawn={6000, 10000} },
-    {id=53,  obj=Objects.Barley, minLvl=10,  itemID=400,  xp=15, respawn={6000, 10000} },
-    {id=57,  obj=Objects.Oats,   minLvl=20,  itemID=533,  xp=20, respawn={6000, 10000} },
-    {id=46,  obj=Objects.Hop,    minLvl=30,  itemID=401,  xp=25, respawn={6000, 10000} },
-    {id=50,  obj=Objects.Flax,   minLvl=40,  itemID=423,  xp=30, respawn={6000, 10000} },
-    {id=159, obj=Objects.Rice,   minLvl=50,  itemID=7018, xp=35, respawn={6000, 10000} },
-    {id=52,  obj=Objects.Rye,    minLvl=50,  itemID=532,  xp=35, respawn={6000, 10000} },
-    {id=58,  obj=Objects.Malt,   minLvl=50,  itemID=405,  xp=40, respawn={6000, 10000} },
-    {id=54,  obj=Objects.Hemp,   minLvl=50,  itemID=425,  xp=45, respawn={6000, 10000} },
+    {id=45,  obj=Objects.Wheat,  minLvl=0,   itemID=289,  xp=10, respawn={180000, 360000} },
+    {id=53,  obj=Objects.Barley, minLvl=10,  itemID=400,  xp=15, respawn={240000, 420000} },
+    {id=57,  obj=Objects.Oats,   minLvl=20,  itemID=533,  xp=20, respawn={300000, 480000} },
+    {id=46,  obj=Objects.Hop,    minLvl=30,  itemID=401,  xp=25, respawn={360000, 540000} },
+    {id=50,  obj=Objects.Flax,   minLvl=40,  itemID=423,  xp=30, respawn={420000, 600000} },
+    {id=159, obj=Objects.Rice,   minLvl=50,  itemID=7018, xp=35, respawn={480000, 660000} },
+    {id=52,  obj=Objects.Rye,    minLvl=50,  itemID=532,  xp=35, respawn={510000, 690000} },
+    {id=58,  obj=Objects.Malt,   minLvl=50,  itemID=405,  xp=40, respawn={540000, 720000} },
+    {id=54,  obj=Objects.Hemp,   minLvl=50,  itemID=425,  xp=45, respawn={660000, 900000} },
 }
 
 local requirements = {jobID = jobID, toolType = toolType}

--- a/scripts/data/skills/job_fisher.lua
+++ b/scripts/data/skills/job_fisher.lua
@@ -2,20 +2,19 @@ local jobID = FishermanJob
 local toolIDs = {596, 1860, 1861, 1862, 1863, 1864, 1865, 1866, 1867, 1868, 8541}
 local rareFishChance = 0.1
 
---FIXME timing
 local gatherSkills = {
-    {id=136,  obj=Objects.Snapper,        xp=5,  minLvl=0,  respawn={6000, 10000}, fishes={2187}, toolID = 2188 },
-    {id=140,  obj=Objects.StrangeShadow,  xp=50, minLvl=0,  respawn={6000, 10000}, fishes={1759} },
+    {id=136,  obj=Objects.Snapper,        xp=5,  minLvl=0,  respawn={240000, 480000},   fishes={2187}, toolID = 2188 },
+    {id=140,  obj=Objects.StrangeShadow,  xp=50, minLvl=0,  respawn={900000, 1800000},  fishes={1759} },
 
-    {id=124,  obj=Objects.SmallRiverFish, xp=10, minLvl=0,  respawn={6000, 10000}, fishes={1782, 1844, 603} },
-    {id=125,  obj=Objects.RiverFish,      xp=15, minLvl=10, respawn={6000, 10000}, fishes={1844, 603, 1847, 1794} },
-    {id=126,  obj=Objects.BigRiverFish,   xp=30, minLvl=40, respawn={6000, 10000}, fishes={603, 1847, 1794, 1779} },
-    {id=127,  obj=Objects.GiantRiverFish, xp=45, minLvl=70, respawn={6000, 10000}, fishes={1847, 1794, 1779, 1801} },
+    {id=124,  obj=Objects.SmallRiverFish, xp=10, minLvl=0,  respawn={300000, 600000},   fishes={1782, 1844, 603} },
+    {id=125,  obj=Objects.RiverFish,      xp=15, minLvl=10, respawn={360000, 720000},   fishes={1844, 603, 1847, 1794} },
+    {id=126,  obj=Objects.BigRiverFish,   xp=30, minLvl=40, respawn={480000, 960000},   fishes={603, 1847, 1794, 1779} },
+    {id=127,  obj=Objects.GiantRiverFish, xp=45, minLvl=70, respawn={600000, 1200000},  fishes={1847, 1794, 1779, 1801} },
 
-    {id=128,  obj=Objects.SmallSeaFish,   xp=10, minLvl=0,  respawn={6000, 10000}, fishes={598, 1757, 1750} },
-    {id=129,  obj=Objects.SeaFish,        xp=20, minLvl=20, respawn={6000, 10000}, fishes={1757, 1805, 600} },
-    {id=130,  obj=Objects.BigSeaFish,     xp=35, minLvl=50, respawn={6000, 10000}, fishes={1805, 1750, 1784, 600} },
-    {id=131,  obj=Objects.GiantSeaFish,   xp=50, minLvl=75, respawn={6000, 10000}, fishes={600, 1805, 602, 1784} },
+    {id=128,  obj=Objects.SmallSeaFish,   xp=10, minLvl=0,  respawn={300000, 660000},   fishes={598, 1757, 1750} },
+    {id=129,  obj=Objects.SeaFish,        xp=20, minLvl=20, respawn={420000, 840000},   fishes={1757, 1805, 600} },
+    {id=130,  obj=Objects.BigSeaFish,     xp=35, minLvl=50, respawn={540000, 1080000},  fishes={1805, 1750, 1784, 600} },
+    {id=131,  obj=Objects.GiantSeaFish,   xp=50, minLvl=75, respawn={720000, 1440000},  fishes={600, 1805, 602, 1784} },
 }
 
 -- Empty fish

--- a/scripts/data/skills/job_lumberjack.lua
+++ b/scripts/data/skills/job_lumberjack.lua
@@ -3,22 +3,22 @@ local toolType = 19
 
 -- TODO: Fix respawn timers
 local gatherSkills = {
-    {id=6,   obj=Objects.Ash,        minLvl=0,   itemID=303,  xp=10, respawn={6000, 10000} },
-    {id=39,  obj=Objects.Chestnut,   minLvl=10,  itemID=473,  xp=15, respawn={6000, 10000} },
-    {id=40,  obj=Objects.Walnut,     minLvl=20,  itemID=476,  xp=20, respawn={6000, 10000} },
-    {id=10,  obj=Objects.Oak,        minLvl=30,  itemID=460,  xp=25, respawn={6000, 10000} },
-    {id=139, obj=Objects.Bombu,      minLvl=35,  itemID=2358, xp=30, respawn={6000, 10000} },
-    {id=141, obj=Objects.Oliviolet,  minLvl=35,  itemID=2357, xp=30, respawn={6000, 10000} },
-    {id=37,  obj=Objects.Maple,      minLvl=40,  itemID=471,  xp=35, respawn={6000, 10000} },
-    {id=33,  obj=Objects.Yew,        minLvl=50,  itemID=461,  xp=40, respawn={6000, 10000} },
-    {id=154, obj=Objects.Bamboo,     minLvl=50,  itemID=7013, xp=40, respawn={6000, 10000} },
-    {id=41,  obj=Objects.Cherry,     minLvl=60,  itemID=474,  xp=45, respawn={6000, 10000} },
-    {id=34,  obj=Objects.Ebony,      minLvl=70,  itemID=449,  xp=50, respawn={6000, 10000} },
-    {id=174, obj=Objects.Kaliptus,   minLvl=75,  itemID=7925, xp=55, respawn={6000, 10000} },
-    {id=38,  obj=Objects.Charm,      minLvl=80,  itemID=472,  xp=65, respawn={6000, 10000} },
-    {id=155, obj=Objects.DarkBamboo, minLvl=80,  itemID=7016, xp=65, respawn={6000, 10000} },
-    {id=35,  obj=Objects.Elm,        minLvl=90,  itemID=470,  xp=70, respawn={6000, 10000} },
-    {id=158, obj=Objects.HolyBamboo, minLvl=100, itemID=7014, xp=75, respawn={6000, 10000} },
+    {id=6,   obj=Objects.Ash,        minLvl=0,   itemID=303,  xp=10, respawn={600000, 840000} },
+    {id=39,  obj=Objects.Chestnut,   minLvl=10,  itemID=473,  xp=15, respawn={660000, 900000} },
+    {id=40,  obj=Objects.Walnut,     minLvl=20,  itemID=476,  xp=20, respawn={720000, 960000} },
+    {id=10,  obj=Objects.Oak,        minLvl=30,  itemID=460,  xp=25, respawn={780000, 1080000} },
+    {id=139, obj=Objects.Bombu,      minLvl=35,  itemID=2358, xp=30, respawn={840000, 1140000} },
+    {id=141, obj=Objects.Oliviolet,  minLvl=35,  itemID=2357, xp=30, respawn={840000, 1200000} },
+    {id=37,  obj=Objects.Maple,      minLvl=40,  itemID=471,  xp=35, respawn={900000, 1260000} },
+    {id=33,  obj=Objects.Yew,        minLvl=50,  itemID=461,  xp=40, respawn={1020000, 1380000} },
+    {id=154, obj=Objects.Bamboo,     minLvl=50,  itemID=7013, xp=40, respawn={1020000, 1380000} },
+    {id=41,  obj=Objects.Cherry,     minLvl=60,  itemID=474,  xp=45, respawn={1080000, 1440000} },
+    {id=34,  obj=Objects.Ebony,      minLvl=70,  itemID=449,  xp=50, respawn={1200000, 1560000} },
+    {id=174, obj=Objects.Kaliptus,   minLvl=75,  itemID=7925, xp=55, respawn={1320000, 1680000} },
+    {id=38,  obj=Objects.Charm,      minLvl=80,  itemID=472,  xp=65, respawn={1440000, 1800000} },
+    {id=155, obj=Objects.DarkBamboo, minLvl=80,  itemID=7016, xp=65, respawn={1440000, 1800000} },
+    {id=35,  obj=Objects.Elm,        minLvl=90,  itemID=470,  xp=70, respawn={4440000, 7200000} },
+    {id=158, obj=Objects.HolyBamboo, minLvl=100, itemID=7014, xp=75, respawn={5400000, 10800000} },
 }
 
 registerGatherJobSkills(jobID, {toolType=toolType}, gatherSkills)

--- a/scripts/data/skills/job_miner.lua
+++ b/scripts/data/skills/job_miner.lua
@@ -4,17 +4,17 @@ local toolType = 21
 
 --FIXME timing / Reward
 local gatherSkills = {
-    {id=24,  obj=Objects.Iron,      minLvl=0,   itemID=312,  xp=10, respawn={6000, 10000} },
-    {id=29,  obj=Objects.Copper,    minLvl=10,  itemID=441,  xp=15, respawn={6000, 10000} },
-    {id=30,  obj=Objects.Bronze,    minLvl=20,  itemID=442,  xp=20, respawn={6000, 10000} },
-    {id=28,  obj=Objects.Cobalt,    minLvl=30,  itemID=443,  xp=25, respawn={6000, 10000} },
-    {id=55,  obj=Objects.Manganese, minLvl=40,  itemID=445,  xp=30, respawn={6000, 10000} },
-    {id=25,  obj=Objects.Tin,       minLvl=50,  itemID=444,  xp=35, respawn={6000, 10000} },
-    {id=56,  obj=Objects.Silicate,  minLvl=50,  itemID=7032, xp=35, respawn={6000, 10000} },
-    {id=26,  obj=Objects.Silver,    minLvl=60,  itemID=350,  xp=40, respawn={6000, 10000} },
-    {id=161, obj=Objects.Bauxite,   minLvl=70,  itemID=446,  xp=45, respawn={6000, 10000} },
-    {id=162, obj=Objects.Gold,      minLvl=80,  itemID=313,  xp=50, respawn={6000, 10000} },
-    {id=161, obj=Objects.Dolomite,  minLvl=100, itemID=7033, xp=50, respawn={6000, 10000} },
+    {id=24,  obj=Objects.Iron,      minLvl=0,   itemID=312,  xp=10, respawn={600000, 780000} },
+    {id=29,  obj=Objects.Copper,    minLvl=10,  itemID=441,  xp=15, respawn={660000, 900000} },
+    {id=30,  obj=Objects.Bronze,    minLvl=20,  itemID=442,  xp=20, respawn={720000, 960000} },
+    {id=28,  obj=Objects.Cobalt,    minLvl=30,  itemID=443,  xp=25, respawn={840000, 1140000} },
+    {id=55,  obj=Objects.Manganese, minLvl=40,  itemID=445,  xp=30, respawn={960000, 1260000} },
+    {id=25,  obj=Objects.Tin,       minLvl=50,  itemID=444,  xp=35, respawn={1080000, 1380000} },
+    {id=56,  obj=Objects.Silicate,  minLvl=50,  itemID=7032, xp=35, respawn={1080000, 1440000} },
+    {id=26,  obj=Objects.Silver,    minLvl=60,  itemID=350,  xp=40, respawn={1200000, 1620000} },
+    {id=161, obj=Objects.Bauxite,   minLvl=70,  itemID=446,  xp=45, respawn={1500000, 1980000} },
+    {id=162, obj=Objects.Gold,      minLvl=80,  itemID=313,  xp=50, respawn={1800000, 2400000} },
+    {id=161, obj=Objects.Dolomite,  minLvl=100, itemID=7033, xp=50, respawn={2100000, 2700000} },
 }
 
 registerGatherJobSkills(jobID, {toolType=toolType}, gatherSkills)


### PR DESCRIPTION
## Summary
- expand farmer resource respawn windows to 3–15 minutes depending on crop level
- apply 5–20 minute windows for alchemist plants, with hemp and orchids on the long end
- fine-tune lumberjack respawns so elm returns in roughly 1h14–2h and holy bamboo in 1.5–3h
- lengthen fisherman node respawn windows to mid-range delays so higher-tier catches sit between farmers and lumberjacks

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c841d5ba388329bc2e704b05f8957d